### PR TITLE
implement guest trial conversion flow and strict expiration

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -24,7 +24,7 @@
 		</div>
 
 		<CookiesConsentBanner :bottom-offset="cookieBannerOffset" />
-
+		<GuestInfoDialog />
 		<AuthDialog />
 	</div>
 </template>
@@ -43,6 +43,7 @@ import NavBar from "@/components/navbar/NavBar.vue";
 import MobileTabBar from "@/components/navbar/MobileTabBar.vue";
 import CookiesConsentBanner from "@/components/CookiesConsentBanner.vue";
 import AuthDialog from "@/components/login_view/AuthDialog.vue";
+import GuestInfoDialog from "@/components/navbar/GuestInfoDialog.vue";
 import Divider from "primevue/divider";
 import { watch } from "vue";
 

--- a/src/components/home_view/GuestExpiredModal.vue
+++ b/src/components/home_view/GuestExpiredModal.vue
@@ -1,9 +1,9 @@
 <template>
 	<Dialog
-		v-model:visible="showModal"
+		:visible="authStore.isGuestExpired && !authStore.isAuthDialogOpen"
 		modal
-		:dismissableMask="false"
 		:closable="false"
+		:dismissableMask="false"
 		:closeOnEscape="false"
 		:show-header="false"
 		class="hs-dialog w-[clamp(22rem,85vw,42rem)]">
@@ -12,55 +12,39 @@
 				class="hs-dialog-hero-bg"
 				aria-hidden="true"></div>
 			<span class="hs-dialog-emoji">⏳</span>
-			<h3 class="hs-dialog-title">Koniec okresu próbnego!</h3>
-			<p class="hs-dialog-subtitle">Czas zachować swoje dane</p>
+			<h3 class="hs-dialog-title">End of trial period!</h3>
+			<p class="hs-dialog-subtitle">Time to save your data</p>
 		</div>
 
 		<div
 			class="hs-dialog-body flex flex-col items-center justify-center text-center">
 			<p
 				class="text-[0.95rem] leading-relaxed text-gray-600 dark:text-gray-400 mt-2 mb-2">
-				Minęło 7 dni od uruchomienia aplikacji jako gość. Załóż darmowe konto,
-				aby odblokować pełen dostęp i nie stracić swojej dotychczasowej historii
-				celów i nawyków.
+				7 days have passed since you started using the app as a guest. Create a
+				free account, to unlock full access and avoid losing your current
+				history of goals and habits.
 			</p>
 		</div>
 
 		<div class="hs-dialog-footer !justify-center">
 			<button
 				class="hs-done-btn w-full sm:w-3/4"
-				@click="goToRegister">
-				Przejdź do logowania
+				@click="openAuthModal">
+				Go to login
 			</button>
 		</div>
 	</Dialog>
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from "vue";
 import { useAuthStore } from "@/stores/auth";
-import { useRouter, useRoute } from "vue-router";
 import Dialog from "primevue/dialog";
 
 const authStore = useAuthStore();
-const router = useRouter();
-const route = useRoute(); // <-- Dodajemy użycie aktualnej ścieżki
 
-const showModal = ref(false);
-
-// Wyświetlamy modal TYLKO wtedy, gdy:
-// 1. Czas gościa wygasł
-// 2. NIE jesteśmy na stronie logowania (żeby go nie blokować)
-watch(
-	() => authStore.isGuestExpired && route.name !== "login",
-	(shouldShow) => {
-		showModal.value = shouldShow;
-	},
-	{ immediate: true },
-);
-
-const goToRegister = () => {
-	router.push({ name: "login" });
+// Funkcja otwiera formularz logowania/rejestracji w formie modalu
+const openAuthModal = () => {
+	authStore.isAuthDialogOpen = true;
 };
 </script>
 

--- a/src/components/navbar/GuestInfoDialog.vue
+++ b/src/components/navbar/GuestInfoDialog.vue
@@ -1,0 +1,55 @@
+<template>
+	<Dialog
+		v-model:visible="authStore.isGuestInfoModalOpen"
+		modal
+		header="Don't lose your progress!"
+		:style="{ width: '90%', maxWidth: '400px' }"
+		:dismissableMask="true"
+		:closable="false">
+		<div class="flex flex-col gap-4 text-surface-700 dark:text-surface-300">
+			<p class="m-0 leading-relaxed">
+				You are currently using a temporary guest account. Create a free account
+				to permanently save your habits and access them safely on any device.
+			</p>
+
+			<div
+				class="flex items-center gap-3 p-3 bg-orange-50 dark:bg-orange-900/20 text-orange-700 dark:text-orange-400 rounded-xl border border-orange-200 dark:border-orange-800/50">
+				<i class="pi pi-clock text-xl"></i>
+				<span class="font-medium">
+					Your guest account will expire in
+					<span class="font-bold text-orange-600 dark:text-orange-300"
+						>{{ authStore.guestDaysRemaining }} days</span
+					>.
+				</span>
+			</div>
+		</div>
+
+		<template #footer>
+			<div class="flex gap-2 w-full mt-2">
+				<button
+					class="flex-1 px-4 py-2 bg-transparent text-surface-500 hover:text-surface-700 dark:text-surface-400 dark:hover:text-surface-200 rounded-lg transition-colors font-medium cursor-pointer border-none"
+					@click="authStore.isGuestInfoModalOpen = false">
+					Maybe later
+				</button>
+				<button
+					class="flex-1 px-4 py-2 bg-primary-500 hover:bg-primary-600 text-white rounded-lg transition-colors font-semibold cursor-pointer border-none shadow-sm"
+					@click="proceedToAuth">
+					Create Account
+				</button>
+			</div>
+		</template>
+	</Dialog>
+</template>
+
+<script setup lang="ts">
+import { useAuthStore } from "@/stores/auth";
+import Dialog from "primevue/dialog";
+
+const authStore = useAuthStore();
+
+// Zamykamy info i otwieramy logowanie
+const proceedToAuth = () => {
+	authStore.isGuestInfoModalOpen = false;
+	authStore.isAuthDialogOpen = true;
+};
+</script>

--- a/src/components/navbar/MobileTabBar.vue
+++ b/src/components/navbar/MobileTabBar.vue
@@ -6,6 +6,14 @@
 			class="tab-btn"
 			:class="{ active: activeTab === tab.id }"
 			@click="onTab(tab)">
+			<span
+				v-if="
+					tab.id === 'profile' &&
+					authStore.isGuest &&
+					authStore.showGuestNotification
+				"
+				class="absolute top-1.5 right-[25%] w-2.5 h-2.5 bg-red-500 rounded-full animate-pulse border-2 border-white dark:border-gray-900 z-10"></span>
+
 			<i :class="['pi', tab.icon, 'tab-icon']"></i>
 			<span class="tab-label">{{ tab.label }}</span>
 		</button>
@@ -35,9 +43,7 @@
 							"></i>
 					</div>
 					<div>
-						<h4 class="font-semibold m-0 text-c">
-							Dark Mode
-						</h4>
+						<h4 class="font-semibold m-0 text-c">Dark Mode</h4>
 						<p class="text-sm text-c m-0">Change app appearance</p>
 					</div>
 				</div>
@@ -56,9 +62,7 @@
 							"></i>
 					</div>
 					<div>
-						<h4 class="font-semibold m-0 text-c">
-							Sound Effects
-						</h4>
+						<h4 class="font-semibold m-0 text-c">Sound Effects</h4>
 						<p class="text-sm text-c m-0">Play UI sounds</p>
 					</div>
 				</div>
@@ -77,12 +81,8 @@
 							"></i>
 					</div>
 					<div>
-						<h4 class="font-semibold m-0 text-b">
-							Animations
-						</h4>
-						<p class="text-sm text-c m-0">
-							Confetti and visual effects
-						</p>
+						<h4 class="font-semibold m-0 text-b">Animations</h4>
+						<p class="text-sm text-c m-0">Confetti and visual effects</p>
 					</div>
 				</div>
 				<ToggleSwitch v-model="preferencesStore.animationsEnabled" />
@@ -150,6 +150,7 @@ import { ref, computed } from "vue";
 import { storeToRefs } from "pinia";
 import { useCarouselStore } from "@/stores/useCarouselStore";
 import LegalDocumentsDialog from "@/components/legal/LegalDocumentsDialog.vue";
+import { useAuthStore } from "@/stores/auth";
 
 // 1. Zastępujemy commonStore naszym nowym preferencesStore
 import { usePreferencesStore } from "@/stores/userPreferences";
@@ -160,6 +161,7 @@ import Sidebar from "primevue/sidebar";
 import ToggleSwitch from "primevue/toggleswitch"; // Lub "primevue/inputswitch" w starszym PrimeVue
 import Button from "primevue/button";
 
+const authStore = useAuthStore();
 const carouselStore = useCarouselStore();
 const preferencesStore = usePreferencesStore();
 const cookieConsentStore = useCookieConsentStore();

--- a/src/components/navbar/NavBar.vue
+++ b/src/components/navbar/NavBar.vue
@@ -17,6 +17,14 @@
 					:class="preferencesStore.isDarkMode ? 'pi pi-sun' : 'pi pi-moon'"></i>
 			</button>
 
+			<button
+				v-if="isGuest && authStore.showGuestNotification"
+				class="w-[2.3rem] h-[2.3rem] rounded-[0.85rem] flex items-center justify-center bg-transparent text-orange-500 hover:bg-surface-100 dark:text-orange-400 dark:hover:bg-surface-800 transition-colors border-none cursor-pointer"
+				@click="authStore.isGuestInfoModalOpen = true">
+				<i
+					class="pi pi-bell text-[1.15rem] bell-shake-animation"
+					@animationiteration="playNotification"></i>
+			</button>
 			<div
 				class="avatar-btn"
 				@click="toggle">
@@ -222,6 +230,46 @@
 			</Sidebar>
 		</div>
 	</div>
+
+	<Dialog
+		v-model:visible="isGuestInfoModalOpen"
+		modal
+		header="Don't lose your progress!"
+		:style="{ width: '90%', maxWidth: '400px' }"
+		:dismissableMask="true">
+		<div class="flex flex-col gap-4 text-surface-700 dark:text-surface-300">
+			<p class="m-0 leading-relaxed">
+				You are currently using a temporary guest account. Create a free account
+				to permanently save your habits and access them safely on any device.
+			</p>
+
+			<div
+				class="flex items-center gap-3 p-3 bg-orange-50 dark:bg-orange-900/20 text-orange-700 dark:text-orange-400 rounded-xl border border-orange-200 dark:border-orange-800/50">
+				<i class="pi pi-clock text-xl"></i>
+				<span class="font-medium">
+					Your guest account will expire in
+					<span class="font-bold text-orange-600 dark:text-orange-300"
+						>{{ authStore.guestDaysRemaining }} days</span
+					>.
+				</span>
+			</div>
+		</div>
+
+		<template #footer>
+			<div class="flex gap-2 w-full mt-2">
+				<button
+					class="flex-1 px-4 py-2 bg-transparent text-surface-500 hover:text-surface-700 dark:text-surface-400 dark:hover:text-surface-200 rounded-lg transition-colors font-medium cursor-pointer border-none"
+					@click="isGuestInfoModalOpen = false">
+					Maybe later
+				</button>
+				<button
+					class="flex-1 px-4 py-2 bg-primary-500 hover:bg-primary-600 text-white rounded-lg transition-colors font-semibold cursor-pointer border-none shadow-sm"
+					@click="proceedToAuth">
+					Create Account
+				</button>
+			</div>
+		</template>
+	</Dialog>
 </template>
 
 <script setup lang="ts">
@@ -238,6 +286,10 @@ import { usePreferencesStore } from "@/stores/userPreferences";
 import { useCookieConsentStore } from "@/stores/cookieConsent";
 import Button from "primevue/button";
 import { useRouter } from "vue-router";
+import { watch, onBeforeUnmount } from "vue";
+import { useSound } from "@/utils/useSound";
+
+const { playNotification } = useSound();
 const router = useRouter();
 const isGuest = computed(() => user.value?.isAnonymous ?? false);
 
@@ -341,6 +393,15 @@ const logOut = async () => {
 	await authStore.logout();
 	authStore.isAuthDialogOpen = true;
 };
+
+watch(
+	() => authStore.showGuestNotification,
+	(isVisible) => {
+		if (isVisible) {
+			playNotification();
+		}
+	},
+);
 </script>
 
 <style scoped>
@@ -555,5 +616,37 @@ const logOut = async () => {
 :where(.my-app-dark, .my-app-dark *) .popover-item-logout:hover {
 	background: color-mix(in srgb, var(--p-red-900) 20%, transparent);
 	color: var(--p-red-400);
+}
+
+@keyframes bell-shake {
+	0%,
+	100% {
+		transform: rotate(0) scale(1);
+	}
+	3%,
+	5% {
+		transform: rotate(0) scale(1.15);
+	} /* Płynne powiększenie na start */
+	7%,
+	11%,
+	15%,
+	19%,
+	23% {
+		transform: rotate(15deg) scale(1.15);
+	}
+	9%,
+	13%,
+	17%,
+	21% {
+		transform: rotate(-15deg) scale(1.15);
+	}
+	25% {
+		transform: rotate(0) scale(1);
+	} /* Koniec bujania po 1.25s, potem cisza do 5s */
+}
+
+.bell-shake-animation {
+	animation: bell-shake 5s infinite ease-in-out;
+	transform-origin: top center;
 }
 </style>

--- a/src/components/navbar/ProfileDialog.vue
+++ b/src/components/navbar/ProfileDialog.vue
@@ -216,9 +216,12 @@
 						border: 1px solid var(--p-orange-200);
 					">
 					<i class="pi pi-clock"></i>
-					<span
-						>Left free days: <strong>{{ daysLeft }}</strong></span
-					>
+					<span class="font-medium">
+						Your guest account will expire in
+						<span class="font-bold text-orange-600 dark:text-orange-300"
+							>{{ authStore.guestDaysRemaining }} days</span
+						>.
+					</span>
 				</div>
 				<p
 					style="
@@ -255,31 +258,11 @@ import RegisterForm from "@/components/login_view/RegisterForm.vue";
 const visible = defineModel<boolean>({ default: false });
 
 const authStore = useAuthStore();
-const { user, hasPasswordProvider } = storeToRefs(authStore);
+const { user, hasPasswordProvider, guestDaysRemaining } =
+	storeToRefs(authStore);
 
 // Sprawdzamy, czy użytkownik jest gościem
 const isGuest = computed(() => user.value?.isAnonymous ?? false);
-
-const daysLeft = computed(() => {
-	const creationTime = user.value?.metadata.creationTime;
-
-	if (!isGuest.value || !creationTime) return 0;
-
-	const createdDate = new Date(creationTime);
-	const now = new Date();
-
-	// Różnica w czasie (w milisekundach)
-	const diffTime = now.getTime() - createdDate.getTime();
-
-	// Przeliczenie na pełne dni
-	const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
-
-	// Od 7 dni odejmujemy te, które już minęły
-	const remaining = 7 - diffDays;
-
-	// Upewniamy się, że nie zejdzie poniżej 0
-	return remaining > 0 ? remaining : 0;
-});
 
 // === User data ===
 const userEmail = computed(() => user.value?.email ?? "");

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { ref, computed } from "vue";
+import { ref, computed, watch } from "vue";
 import {
 	signInWithEmailAndPassword,
 	createUserWithEmailAndPassword,
@@ -11,7 +11,8 @@ import {
 	User,
 } from "firebase/auth";
 import { doc, setDoc, serverTimestamp } from "firebase/firestore";
-import { auth, db } from "@/firebase"; // Upewnij się, że ścieżka do Twojego pliku configu jest poprawna
+import { auth, db } from "@/firebase";
+import { toDateKey } from "@/utils/timeUtils";
 
 export const useAuthStore = defineStore("auth", () => {
 	// ==========================================
@@ -21,6 +22,21 @@ export const useAuthStore = defineStore("auth", () => {
 	const loading = ref(true);
 	const error = ref<string | null>(null); // Przydatne do rzucania błędami w UI
 	const isAuthDialogOpen = ref(false);
+	const isGuestInfoModalOpen = ref(false);
+	const showGuestNotification = ref(
+		localStorage.getItem("guestNotification") === "true",
+	);
+
+	// Automatycznie zapisujemy do localStorage lub CZYŚCIMY, gdy flaga zgaśnie
+	watch(showGuestNotification, (newValue) => {
+		if (newValue) {
+			localStorage.setItem("guestNotification", "true");
+		} else {
+			// Gdy użytkownik się zaloguje/zarejestruje i flaga zmieni się na false,
+			// fizycznie usuwamy ślad z przeglądarki!
+			localStorage.removeItem("guestNotification");
+		}
+	});
 
 	// ==========================================
 	// 2. GETTERY (Computed)
@@ -36,30 +52,36 @@ export const useAuthStore = defineStore("auth", () => {
 	const isGuest = computed(() => user.value?.isAnonymous ?? false);
 
 	// Sprawdzamy czy minęło 7 dni dla gościa
+	// isGuestExpired też staje się funkcją
 	const isGuestExpired = computed(() => {
+		return guestDaysRemaining.value <= 6;
+		// return guestDaysRemaining.value === 0;
+	});
+
+	// Zwraca ilość dni jako zwykła funkcja, aby czas zawsze był "świeży"
+	const guestDaysRemaining = computed(() => {
 		if (
 			!user.value ||
 			!user.value.isAnonymous ||
 			!user.value.metadata.creationTime
-		)
-			return false;
+		) {
+			return 7;
+		}
 
-		const creationTime = new Date(user.value.metadata.creationTime).getTime();
-		const now = Date.now();
-		const daysSinceCreation = (now - creationTime) / (1000 * 60 * 60 * 24);
+		const creationKey = toDateKey(new Date(user.value.metadata.creationTime));
+		// Używamy po prostu zwykłego now Date() - bez żadnych triggerów
+		const todayKey = toDateKey(new Date());
 
-		return daysSinceCreation >= 7;
+		const creationTime = new Date(creationKey).getTime();
+		const todayTime = new Date(todayKey).getTime();
+
+		const daysSinceCreation = Math.round(
+			(todayTime - creationTime) / (1000 * 60 * 60 * 24),
+		);
+		const remaining = 7 - daysSinceCreation;
+
+		return remaining > 0 ? remaining : 0;
 	});
-
-	// const isGuestExpired = computed(() => {
-	// 	// Zamiast zwracać "null", jeśli nie ma usera, twardo zwracamy false
-	// 	if (!user.value || !user.value.isAnonymous) {
-	// 		return false;
-	// 	}
-
-	// 	// Jeśli dotarliśmy tutaj, to user istnieje i jest gościem
-	// 	return true;
-	// });
 
 	// ==========================================
 	// 3. AKCJE (Actions)
@@ -105,6 +127,7 @@ export const useAuthStore = defineStore("auth", () => {
 		error.value = null;
 		try {
 			await signInWithEmailAndPassword(auth, email, password);
+			showGuestNotification.value = false;
 		} catch (err: any) {
 			error.value = err.message;
 			throw err;
@@ -130,6 +153,7 @@ export const useAuthStore = defineStore("auth", () => {
 					},
 					{ merge: true },
 				);
+				showGuestNotification.value = false;
 			} else {
 				// Zwykła rejestracja (jeśli ktoś po prostu zakłada konto z wylogowanego ekranu)
 				const userCredential = await createUserWithEmailAndPassword(
@@ -146,6 +170,7 @@ export const useAuthStore = defineStore("auth", () => {
 					},
 					{ merge: true },
 				);
+				showGuestNotification.value = false;
 			}
 		} catch (err: any) {
 			error.value = err.message;
@@ -178,5 +203,8 @@ export const useAuthStore = defineStore("auth", () => {
 		logout,
 		loginAsGuest,
 		isAuthDialogOpen,
+		showGuestNotification,
+		guestDaysRemaining,
+		isGuestInfoModalOpen,
 	};
 });

--- a/src/stores/habbits.ts
+++ b/src/stores/habbits.ts
@@ -360,7 +360,13 @@ export const useHabbitsStore = defineStore("habbits", () => {
 							goalsSnapshot: [...snapshotToSave],
 						});
 					}
+
 					addToRecentHabbits(habbit.name);
+
+					// !!! TO JEST NASZ KLUCZOWY DODATEK !!!
+					if (authStore.isGuest) {
+						authStore.showGuestNotification = true;
+					}
 				} catch (error) {
 					console.error("Error adding habbit to Firestore:", error);
 				}

--- a/src/stores/todos.ts
+++ b/src/stores/todos.ts
@@ -115,6 +115,9 @@ export const useTodosStore = defineStore("todos", () => {
 
 				userTodosList.value.push(newTodo);
 
+				if (authStore.isGuest) {
+					authStore.showGuestNotification = true;
+				}
 				const userDocRef = doc(db, "users", userUid.value!!);
 				await updateDoc(userDocRef, { todos: userTodosList.value });
 			},

--- a/src/utils/useSound.ts
+++ b/src/utils/useSound.ts
@@ -85,5 +85,19 @@ export function useSound() {
 		playTone(784, 0.4, "sine", 0.1, melody.length * 0.12);
 	}
 
-	return { playCheck, playUncheck, playAdd, playHabitCheck, playVictory };
+	function playNotification() {
+		if (!preferencesStore.soundEnabled) return;
+
+		// 1046 Hz (C6), czas 0.4s, niska głośność (0.06) żeby nie irytować
+		playTone(1046, 0.4, "sine", 0.06);
+	}
+
+	return {
+		playCheck,
+		playUncheck,
+		playAdd,
+		playHabitCheck,
+		playVictory,
+		playNotification,
+	};
 }


### PR DESCRIPTION
- Refactored `guestDaysRemaining` in authStore to sync perfectly with `toDateKey`
- Added `GuestInfoDialog` to handle desktop notifications seamlessly
- Fixed `GuestExpiredModal` reactivity, enforcing hard lockout and auth modal ping-pong
- Integrated reactive notification badge (pulsing dot) into mobile tab bar
- Centralized `isGuest` state in Pinia store for global single source of truth
- Cleaned up redundant date logic from ProfileView